### PR TITLE
update boringssl to 0.20260526.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,11 +1,11 @@
 .{
     .name = .boringssl,
-    .version = "0.20260508.0",
+    .version = "0.20260526.0",
     .fingerprint = 0x5f0947d235641b12,
     .dependencies = .{
         .boringssl = .{
-            .url = "https://github.com/google/boringssl/archive/d589045a772678d5ca131f4c8087d001b9258380.tar.gz",
-            .hash = "N-V-__8AAO-t0g0Vv4tDWScq8vnEbEMShTyCcdPEgt9syb7p",
+            .url = "https://github.com/google/boringssl/archive/190fa71435c8675b80d7883e5d01858db4c91180.tar.gz",
+            .hash = "N-V-__8AAJhc0w0H8yQ1jOqE3CHmQtOLsdy2qmZ5l4AsJya7",
         },
         .nasm = .{
             .url = "git+https://github.com/allyourcodebase/nasm.git#d7356eadb2d7771542fe74e8fc0668bd78732b59",

--- a/sources.json
+++ b/sources.json
@@ -804,7 +804,9 @@
       "crypto/x509/x509_test.cc",
       "crypto/x509/x509_time_test.cc",
       "crypto/xwing/xwing_test.cc",
-      "third_party/fiat/bedrock_platform_test.cc",
+      "third_party/fiat/bedrock_platform_test.cc"
+    ],
+    "internal_hdrs": [
       "third_party/fiat/bedrock_polyfill_platform.c.inc"
     ],
     "data": [
@@ -901,10 +903,12 @@
       "crypto/pkcs7/test/nss.p7c",
       "crypto/pkcs7/test/openssl_crl.p7c",
       "crypto/pkcs7/test/sign_cert.pem",
+      "crypto/pkcs7/test/sign_cert2.pem",
       "crypto/pkcs7/test/sign_key.pem",
       "crypto/pkcs7/test/sign_sha1.p7s",
       "crypto/pkcs7/test/sign_sha1_key_id.p7s",
       "crypto/pkcs7/test/sign_sha256.p7s",
+      "crypto/pkcs7/test/sign_sha256_cert2.p7s",
       "crypto/pkcs7/test/sign_sha256_key_id.p7s",
       "crypto/pkcs7/test/windows.p7c",
       "crypto/pkcs8/test/bad1.p12",


### PR DESCRIPTION
This updates BoringSSL to 0.20260526.0.