### PR TITLE
fix: Translate-c

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ Declare a source file that imports the C includes.
 
 For example:
 
-src/my_ssl.c:
+`src/my_ssl.c:`
 ```c
 #include "openssl/ssl.h"
 ...
 ...
 ```
 
-Convert that source file into zig using the declared translate-c dependency.
+Convert that source file into zig using the declared `translate-c` dependency.
 
 ```zig
 // Translate my_ssl.c into zig

--- a/README.md
+++ b/README.md
@@ -12,23 +12,51 @@ zig init
 zig fetch --save git+https://github.com/lukaskastern/boringssl.git
 ```
 
-You can then import `boringssl` in your `build.zig` with:
+You can then link `boringssl` in your `build.zig` with:
 
 ```zig
 const boringssl_dependency = b.dependency("boringssl", .{
     .target = target,
     .optimize = optimize,
 });
-your_exe.linkLibrary(boringssl_dependency.artifact("bcm"));
-your_exe.linkLibrary(boringssl_dependency.artifact("ssl"));
-your_exe.linkLibrary(boringssl_dependency.artifact("crypto"));
+your_module.linkLibrary(boringssl_dependency.artifact("bcm"));
+your_module.linkLibrary(boringssl_dependency.artifact("ssl"));
+your_module.linkLibrary(boringssl_dependency.artifact("crypto"));
 ```
+
+To use the library first declare translate-c as a dependency.
+See [here](https://codeberg.org/ziglang/translate-c) for more information. 
+
+Declare a source file that imports the C includes.
+
+For example:
+
+src/my_ssl.c:
+```c
+#include "openssl/ssl.h"
+...
+...
+```
+
+Convert that source file into zig using the declared translate-c dependency.
+
+```zig
+// Translate my_ssl.c into zig
+const Translator = @import("translate_c").Translator;
+const t: Translator = .init(translate_c, .{
+    .c_source_file = b.path("src/my_ssl.c"),
+    .target = target,
+    .optimize = optimize,
+});
+t.addIncludePath(boringssl_dependency.namedLazyPath("ssl_include"));
+
+your_module.addImport("boringssl", t.mod);
+```
+
 
 And use the library like this:
 ```zig
-const ssl = @cImport({
-    @cInclude("openssl/ssl.h");
-});
+const ssl = @import("boringssl");
 
 const ctx = ssl.EVP_CIPHER_CTX_new();
 ...

--- a/build.zig
+++ b/build.zig
@@ -319,6 +319,5 @@ pub fn build(b: *std.Build) !void {
         b.installArtifact(mod);
     }
 
-    // Install headers directory - should only ssl do this or crypto as well?
-    steps.get("ssl").?.installHeadersDirectory(upstream_root.path(b, "include"), "", .{});
+    b.addNamedLazyPath("ssl_include", upstream_root.path(b, "include"));
 }

--- a/patches/translate_c_pragma.patch
+++ b/patches/translate_c_pragma.patch
@@ -1,0 +1,13 @@
+diff --git a/include/openssl/base.h b/include/openssl/base.h
+index 1ce0e1bb2..ebc058e63 100644
+--- a/include/openssl/base.h
++++ b/include/openssl/base.h
+@@ -148,7 +148,7 @@ extern "C" {
+ // OPENSSL_GNUC_CLANG_PRAGMA emits a pragma on GCC or clang and nothing on other
+ // compilers.
+ #if defined(__GNUC__) || defined(__clang__)
+-#define OPENSSL_GNUC_CLANG_PRAGMA(arg) _Pragma(arg)
++#define OPENSSL_GNUC_CLANG_PRAGMA(arg) 
+ #else
+ #define OPENSSL_GNUC_CLANG_PRAGMA(arg)
+ #endif


### PR DESCRIPTION
This PR fixes an issue with including the C headers from zig code. 
The way to include those headers regressed somewhere between 0.14.1 and 0.16.0.  

This should address https://github.com/allyourcodebase/boringssl/issues/13